### PR TITLE
Add RSS Feed Support Using Atom (RSS)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+gems:
+  - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+# adds RSS support according to...
+# https://help.github.com/articles/atom-rss-feeds-for-github-pages/
+gems:
+  - jekyll-feed


### PR DESCRIPTION
Disclaimer: I don't use jekyll, nor have I created many PRs... so apologies if I'm mucking this up.

This should be fairly simple...
1. Reference: https://help.github.com/articles/atom-rss-feeds-for-github-pages/
2. PR adds the _config.yml specified. This should be added to the Jekyll root. I added it to the root of the gh-pages repo. Unsure if jekyll root and gh-pages root are synonymous 
3. The docs also suggest that you add the `{% feed_meta %}` tag to your layout's `<head>` section to allow browsers to more easily discover your site's feed. I'm probably looking in the wrong place, but I didn't see where this would go.
